### PR TITLE
docs: clarify scopes needed for API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Automate SMS notifications and voice calls through your smart home. Get instant 
 
 - Home Assistant 2023.1.0 or newer
 - A seven.io account with API key ([sign up free](https://app.seven.io/signup))
+  - Make sure your API key has at least `balance`, `sms` and `voice` scopes configured.
 - Credits in your seven.io account for sending messages
 
 ## Installation


### PR DESCRIPTION
Hi!

I had initially a few issues setting up this integration. After a bit of debugging I found that the code first checks the balances to verify if the API key is valid, which is fine, but breaks if you create an API key with too few scopes. 😅 
Following security best practices, I configured the created API key only with the least needed scopes (just `sms` in my case).

This was most likely the same issue as reported in #7, having a hint in the README would have helped a bit. That's why I am creating this PR. :)

Thanks for the service and HA integration! Awesome to see, that there are well-established alternatives to US services. :) 